### PR TITLE
CLI command parser

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1,0 +1,178 @@
+// Package cli has methods to validate the command line input and return the appropriate operation
+// to be executed by the client.
+//
+// When invalid arguments are provided, an error message with details on why the command is invalid is returned.
+// That error message also includes the cli helper message, which can also is shown when the option --help is used.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// HelpPrompt displays the helper message with all the options accepted by rlcp
+const HelpPrompt = `
+rlcp - Remote Linux Command Processor
+
+Usage: rlcp operation argument
+   
+OPERATIONS
+    --help
+        shows this prompt
+
+    run <command>
+        runs the informed <command> on the server. <command> should be a single word or if multiple words, encapsulated by double quotes.
+        this command returns a job id to be used to either query the status, get the output or stop the job later.
+
+        Examples:
+         rlcp run pwd
+         rlcp run "ls -la"
+         rlcp run "tail -f server.log"
+    
+    status <job id>
+        gets the status for the job or an error message if the id is invalid or the user doesn't have the appropriate permissions.
+
+        Example:
+        rlcp status bf7a1eae-8d25-4de5-995b-8c4d3ef8b848
+    
+    output <job id>
+        prints the output for the job or an error message if the id is invalid or the user doesn't have the appropriate permissions.
+
+        Example:
+        rlcp output 8060271e-b776-4444-9e75-bd2e3db3cc7d
+
+    stop <job id>
+        stops the job identified by job id. Returns an error message if the id is invalid or the user doesn't have the appropriate permissions.
+
+        Example:
+        rlcp stop af1f8215-bee7-455d-874a-55f0e3fb20b5`
+
+type Operation uint
+
+const (
+	Run Operation = iota
+	Status
+	Output
+	Stop
+	Help
+)
+
+type ErrInvalidCommand struct {
+	err string
+}
+
+func NewErrInvalidCommand(err string) ErrInvalidCommand {
+	return ErrInvalidCommand{err}
+}
+
+func (e ErrInvalidCommand) Error() string {
+	return e.err
+}
+
+type Option struct {
+	Op   Operation
+	Args []string
+}
+
+func ParseCommand(args []string) (Option, error) {
+	if len(args) == 1 {
+		return Option{}, ErrInvalidCommand{"invalid command"}
+	}
+
+	if len(args) == 2 {
+		if args[1] != "--help" {
+			return Option{}, ErrInvalidCommand{fmt.Sprintf("invalid option: %s", args[1])}
+		}
+		return Option{
+			Op: Help,
+		}, nil
+	}
+
+	if len(args) == 3 {
+		switch args[1] {
+		case "run":
+			runArgs := splitArguments(args[2])
+			return Option{
+				Op:   Run,
+				Args: runArgs,
+			}, nil
+		case "status":
+			return validateOperation(Status, args[2])
+		case "output":
+			return validateOperation(Output, args[2])
+		case "stop":
+			return validateOperation(Stop, args[2])
+		default:
+			return Option{}, ErrInvalidCommand{fmt.Sprintf("invalid option: %s", args[1])}
+		}
+	}
+	return Option{}, NewErrInvalidCommand("invalid command")
+}
+
+// splitArguments leverages the OS parsing on the input, which guarantees that all quotes are balanced.
+// it then constructs a stack to parse nested quotes and only return one argument per outer quote boundary, including any possible inner quotes.
+func splitArguments(cmd string) []string {
+	cmd = strings.Trim(cmd, " ")
+
+	quoteStack := make([]rune, 0)
+
+	args := make([]string, 0)
+	arg := make([]rune, 0)
+
+	for _, r := range cmd {
+		switch r {
+		case ' ':
+			if len(quoteStack) == 0 {
+				if len(arg) > 0 {
+					args = append(args, string(arg))
+					arg = make([]rune, 0)
+				}
+				continue
+			}
+			arg = append(arg, r)
+		case '\\':
+			if len(quoteStack) > 1 {
+				arg = append(arg, r)
+			}
+		case '\'', '"':
+			if len(quoteStack) == 1 && quoteStack[0] == r {
+				quoteStack = make([]rune, 0)
+				args = append(args, string(arg))
+				arg = make([]rune, 0)
+			} else {
+				if len(quoteStack) > 0 {
+					arg = append(arg, r)
+					if quoteStack[len(quoteStack)-1] == r {
+						quoteStack = quoteStack[:len(quoteStack)-1]
+					} else {
+						quoteStack = append(quoteStack, r)
+					}
+				} else {
+					quoteStack = append(quoteStack, r)
+				}
+			}
+		default:
+			arg = append(arg, r)
+		}
+	}
+	if len(arg) > 0 {
+		args = append(args, string(arg))
+	}
+	return args
+}
+
+// validateOperation returns an Option object with the informed operation if the id parameter is a
+// valid uuid, otherwise returns an error
+func validateOperation(op Operation, id string) (Option, error) {
+	_, err := uuid.Parse(id)
+	if err != nil {
+		return Option{}, NewErrInvalidCommand("invalid job id")
+	}
+	return Option{
+		Op:   op,
+		Args: []string{id},
+	}, nil
+}

--- a/cmd/cli/cli_test.go
+++ b/cmd/cli/cli_test.go
@@ -1,0 +1,131 @@
+package cli_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mhsantos/rlcp/cmd/cli"
+)
+
+func TestArguments(t *testing.T) {
+	tcs := []struct {
+		name           string
+		args           []string
+		expectedOption cli.Option
+		expectedError  error
+	}{
+		{
+			name: "valid help command",
+			args: []string{"rlcp", "--help"},
+			expectedOption: cli.Option{
+				Op: cli.Help,
+			},
+		},
+		{
+			name:           "invalid help command",
+			args:           []string{"rlcp", "-help"},
+			expectedOption: cli.Option{},
+			expectedError:  cli.NewErrInvalidCommand("invalid option: -help"),
+		},
+		{
+			name:           "unexisting option",
+			args:           []string{"rlcp", "kill", "process"},
+			expectedOption: cli.Option{},
+			expectedError:  cli.NewErrInvalidCommand("invalid option: kill"),
+		},
+		{
+			name:           "invalid number of arguments",
+			args:           []string{"rlcp", "duck", "and", "cover"},
+			expectedOption: cli.Option{},
+			expectedError:  cli.NewErrInvalidCommand("invalid command"),
+		},
+		{
+			name: "valid run command with single argument",
+			args: []string{"rlcp", "run", "pwd"},
+			expectedOption: cli.Option{
+				Op:   cli.Run,
+				Args: []string{"pwd"},
+			},
+		},
+		{
+			name: "valid run command with multiple arguments",
+			args: []string{"rlcp", "run", "ls -la ../"},
+			expectedOption: cli.Option{
+				Op:   cli.Run,
+				Args: []string{"ls", "-la", "../"},
+			},
+		},
+		{
+			name: "valid run command with 1 level of nested args",
+			args: []string{"rlcp", "run", "echo 'my name is jonas'"},
+			expectedOption: cli.Option{
+				Op:   cli.Run,
+				Args: []string{"echo", "my name is jonas"},
+			},
+		},
+		{
+			name: "valid run command with 2 levels of nested args",
+			args: []string{"rlcp", "run", "sh -c \"echo 'my name is jonas'\""},
+			expectedOption: cli.Option{
+				Op:   cli.Run,
+				Args: []string{"sh", "-c", "echo 'my name is jonas'"},
+			},
+		},
+		{
+			name: "valid status command",
+			args: []string{"rlcp", "status", "af1f8215-bee7-455d-874a-55f0e3fb20b5"},
+			expectedOption: cli.Option{
+				Op:   cli.Status,
+				Args: []string{"af1f8215-bee7-455d-874a-55f0e3fb20b5"},
+			},
+		},
+		{
+			name:           "invalid status command argument",
+			args:           []string{"rlcp", "status", "invalid-uuid"},
+			expectedOption: cli.Option{},
+			expectedError:  cli.NewErrInvalidCommand("invalid job id"),
+		},
+		{
+			name: "valid output command",
+			args: []string{"rlcp", "output", "6c4bc197-b0e4-4ee3-a6be-b3b591ffad70"},
+			expectedOption: cli.Option{
+				Op:   cli.Output,
+				Args: []string{"6c4bc197-b0e4-4ee3-a6be-b3b591ffad70"},
+			},
+		},
+		{
+			name:           "invalid output command argument",
+			args:           []string{"rlcp", "output", "invalid-uuid"},
+			expectedOption: cli.Option{},
+			expectedError:  cli.NewErrInvalidCommand("invalid job id"),
+		},
+		{
+			name: "valid stop command",
+			args: []string{"rlcp", "stop", "cc430a1e-ab90-4cc0-b3b5-0ed22303b99a"},
+			expectedOption: cli.Option{
+				Op:   cli.Stop,
+				Args: []string{"cc430a1e-ab90-4cc0-b3b5-0ed22303b99a"},
+			},
+		},
+		{
+			name:           "invalid stop command argument",
+			args:           []string{"rlcp", "stop", "invalid-uuid"},
+			expectedOption: cli.Option{},
+			expectedError:  cli.NewErrInvalidCommand("invalid job id"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			option, err := cli.ParseCommand(tc.args)
+			if !cmp.Equal(tc.expectedOption, option) {
+				t.Fatalf("Unexpected Option returned. Expected: %v, Actual: %v", tc.expectedOption, option)
+			}
+			if !errors.Is(err, tc.expectedError) {
+				t.Fatal("invalid error returned")
+			}
+		})
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/mhsantos/rlcp
+
+go 1.24.3
+
+require (
+	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
CLI implementation with tests.

Addressing all `--help`, `run`, `status`, `output` and `stop` operations.

For the `run command` operation, currently trusts the OS parsing for balanced double, single and escaped quotes.
Tested with up to 2 levels of nested arguments.

This doesn't include the client to call gRPC, nor the main client, which will be included in another PR.