### PR TITLE
Close listeners whenever a command ends

### DIFF
--- a/cmd/server/internal/executor/log_processor.go
+++ b/cmd/server/internal/executor/log_processor.go
@@ -3,4 +3,5 @@ package executor
 type LogHandler interface {
 	ProcessOutput([]byte) error
 	RegisterListener(chan []byte)
+	CloseListeners()
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -113,6 +113,7 @@ func (s *server) StopJob(ctx context.Context, req *pb.StopRequest) (*emptypb.Emp
 		return nil, status.Errorf(codes.Unknown, "Error killing the process: %v", err)
 	}
 	job.Status = storage.Stopped
+	job.CloseListeners()
 
 	return nil, nil
 }


### PR DESCRIPTION
We had an issue where listeners would continue listening in channels for commands that finished executing.
This change:
1. whenever a client tries to get the output for a command, gets the output and close the channel if the command has already finished
2. iterate over the open listeners and close them whenever a command is stopped